### PR TITLE
0.14.0

### DIFF
--- a/atlasq/queryset/exceptions.py
+++ b/atlasq/queryset/exceptions.py
@@ -12,3 +12,7 @@ class AtlasIndexError(AtlasError):
 
 class AtlasFieldError(AtlasError):
     pass
+
+
+class AtlasQueryError(AtlasError):
+    pass

--- a/atlasq/queryset/queryset.py
+++ b/atlasq/queryset/queryset.py
@@ -159,7 +159,7 @@ class AtlasQuerySet(QuerySet):
         collection = self._collection
         if self._read_preference is not None or self._read_concern is not None:
             collection = self._collection.with_options(read_preference=self._read_preference, read_concern=self._read_concern)
-        self.logger.info(final_pipeline)
+        self.logger.debug(final_pipeline)
         return collection.aggregate(final_pipeline, cursor={}, **kwargs)
 
     def aggregate(self, pipeline, **kwargs):  # pylint: disable=arguments-differ,unused-argument

--- a/atlasq/queryset/queryset.py
+++ b/atlasq/queryset/queryset.py
@@ -3,7 +3,7 @@ import logging
 import time
 from typing import Any, Dict, List, Tuple
 
-from atlasq.queryset.exceptions import AtlasIndexError
+from atlasq.queryset.exceptions import AtlasIndexError, AtlasQueryError
 from atlasq.queryset.index import AtlasIndex
 from atlasq.queryset.node import AtlasQ
 from mongoengine import Q, QuerySet
@@ -102,6 +102,9 @@ class AtlasQuerySet(QuerySet):
                     self._aggrs_query[0]["$search"]["count"] = {"type": "total"}
                 if self._ordering:
                     self._aggrs_query[0]["$search"]["sort"] = dict(self._ordering)
+            else:
+                if self._ordering:
+                    raise AtlasQueryError("Atlas search does not support ordering without filtering.")
             self._aggrs_query += self._get_projections()
             self._aggrs_query += self._other_aggregations
         return self._aggrs_query
@@ -115,15 +118,12 @@ class AtlasQuerySet(QuerySet):
         cursor = super()._cursor
         return cursor
 
-    def order_by(self, *keys, as_aggregation: bool = False):
+    def order_by(self, *keys):
         if not keys:
             return self
         qs: AtlasQuerySet = self.clone()
         order_by: List[Tuple[str, int]] = qs._get_order_by(keys)  # pylint: disable=protected-access
-        if not as_aggregation:
-            qs._ordering = order_by  # pylint: disable=protected-access
-        else:
-            qs._other_aggregations.append({"$sort": dict(order_by)})  # pylint: disable=protected-access
+        qs._ordering = order_by  # pylint: disable=protected-access
         return qs
 
     def __getitem__(self, key):

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -71,6 +71,7 @@ class TestQuerySet(TestBaseCase):
     def test_order_by(self):
         with self.assertRaises(AtlasQueryError):
             qs = self.base.order_by("-time")
+            _ = qs._aggrs
         self.assertEqual(qs._aggrs[0], {"$sort": {"time": 1}})
 
         qs = self.base.filter(name="123").order_by("+time")

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -69,13 +69,13 @@ class TestQuerySet(TestBaseCase):
         self.assertEqual(r, 0)
 
     def test_order_by(self):
-        qs = self.base.order_by("-time", as_aggregation=True)
+        qs = self.base.order_by("-time")
         self.assertEqual(qs._aggrs[0], {"$sort": {"time": -1}})
-        qs = self.base.order_by("+time", as_aggregation=True)
+        qs = self.base.order_by("+time")
         self.assertEqual(qs._aggrs[0], {"$sort": {"time": 1}})
-        qs = self.base.order_by("time", as_aggregation=True)
+        qs = self.base.order_by("time")
         self.assertEqual(qs._aggrs[0], {"$sort": {"time": 1}})
-        qs = self.base.order_by("-time", as_aggregation=True).filter(name="123")
+        qs = self.base.order_by("-time").filter(name="123")
         self.assertEqual(qs._aggrs[1], {"$sort": {"time": -1}})
 
         qs = self.base.filter(name="123").order_by("+time")

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from atlasq import AtlasManager, AtlasQ
-from atlasq.queryset.exceptions import AtlasIndexFieldError
+from atlasq.queryset.exceptions import AtlasIndexFieldError, AtlasQueryError
 from mongoengine import Document, ListField, StringField
 from mongomock import command_cursor
 from mongomock.command_cursor import CommandCursor
@@ -69,14 +69,9 @@ class TestQuerySet(TestBaseCase):
         self.assertEqual(r, 0)
 
     def test_order_by(self):
-        qs = self.base.order_by("-time")
-        self.assertEqual(qs._aggrs[0], {"$sort": {"time": -1}})
-        qs = self.base.order_by("+time")
+        with self.assertRaises(AtlasQueryError):
+            qs = self.base.order_by("-time")
         self.assertEqual(qs._aggrs[0], {"$sort": {"time": 1}})
-        qs = self.base.order_by("time")
-        self.assertEqual(qs._aggrs[0], {"$sort": {"time": 1}})
-        qs = self.base.order_by("-time").filter(name="123")
-        self.assertEqual(qs._aggrs[1], {"$sort": {"time": -1}})
 
         qs = self.base.filter(name="123").order_by("+time")
         self.assertIn("sort", qs._aggrs[0]["$search"])

--- a/tests/queryset/test_queryset.py
+++ b/tests/queryset/test_queryset.py
@@ -72,8 +72,6 @@ class TestQuerySet(TestBaseCase):
         with self.assertRaises(AtlasQueryError):
             qs = self.base.order_by("-time")
             _ = qs._aggrs
-        self.assertEqual(qs._aggrs[0], {"$sort": {"time": 1}})
-
         qs = self.base.filter(name="123").order_by("+time")
         self.assertIn("sort", qs._aggrs[0]["$search"])
         self.assertEqual(qs._aggrs[0]["$search"]["sort"], {"time": 1})


### PR DESCRIPTION
I noticed that, due to the logs added to the `clocked` decorator we have duplicated logs of the performed queries.